### PR TITLE
Adding option to not output calling echoInput in bashWizard script

### DIFF
--- a/bashGeneratorSharedModels/Resources/bashTemplate.sh
+++ b/bashGeneratorSharedModels/Resources/bashTemplate.sh
@@ -88,7 +88,7 @@ __PARSE_INPUT_FILE__
 __REQUIRED_PARAMETERS__
 __LOGGING_SUPPORT_
 
-    echoInput
+__CALL_ECHOINPUT__
     # --- BEGIN USER CODE ---
 __USER_CODE_1__
     # --- END USER CODE ---

--- a/bashGeneratorSharedModels/ScriptDataAPI.cs
+++ b/bashGeneratorSharedModels/ScriptDataAPI.cs
@@ -210,6 +210,8 @@ namespace bashWizardShared
             sbBashScript.Replace("__LOGGING_SUPPORT_", logTemplate.ToString());
             sbBashScript.Replace("__END_LOGGING_SUPPORT__", this.LoggingSupport ? endLogTemplate.ToString() : "");
 
+            sbBashScript.Replace("__CALL_ECHOINPUT__", this.EchoInput ? "   echoInput" : "");
+
             if (this.CreateVerifyDelete)
             {
                 if (!ScriptData.FunctionExists(this.UserCode, "onVerify") && !ScriptData.FunctionExists(this.UserCode, "onDelete") && !ScriptData.FunctionExists(this.UserCode, "onCreate"))
@@ -481,6 +483,7 @@ namespace bashWizardShared
                     }
                 }
 
+                scriptData.EchoInput = (bashWizardCode.IndexOf("    echoInput") > 0);
 
                 //
                 //  find the usage() function and parse it out - this gives us the 4 properties in the ParameterItem below

--- a/bashGeneratorSharedModels/ScriptDataProperties.cs
+++ b/bashGeneratorSharedModels/ScriptDataProperties.cs
@@ -49,6 +49,7 @@ namespace bashWizardShared
                     NotifyPropertyChanged("LoggingSupport");
                     NotifyPropertyChanged("AcceptsInputFile");
                     NotifyPropertyChanged("CreateVerifyDelete");
+                    NotifyPropertyChanged("EchoInput");
                     NotifyPropertyChanged("Warnings");
                     NotifyPropertyChanged("JSON");
                     GenerateBashScript = oldGenerateBashScript;
@@ -110,7 +111,20 @@ namespace bashWizardShared
             return false;
         }
 
-
+        private bool _EchoInput = true;
+        [JsonProperty]
+        public bool EchoInput
+        {
+            get => _EchoInput;
+            set
+            {
+                if (_EchoInput != value)
+                {
+                    _EchoInput = value;
+                    NotifyPropertyChanged();
+                }
+            }
+        }
 
 
         private string _Version = "0.906";


### PR DESCRIPTION
I wanted to optionally not include the call to echoInput. If there is a better way to do it, certainly reject my pull request. I did not update bw script version as I'm not sure all the places to update.  